### PR TITLE
Surge integration for previews

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 ---
 # GitHub Actions workflow for commits pushed to the antora theme repo
 
-name: CI at GitHub
+name: CI
 on:
   push:
     branches: [main]

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,33 @@
+name: Surge PR Preview
+
+on:
+  workflow_run:
+    workflows: [ "Gatsby Publish" ]
+    types:
+      - completed
+      - closed
+
+jobs:
+  preview:
+    runs-on: ubuntu-20.04
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download PR Artifact
+        uses: dawidd6/action-download-artifact@v2
+        if: github.event.workflow_run.type == 'completed'
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: success
+          name: site
+      - uses: afc163/surge-preview@v1
+        id: preview_step
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: site
+          failOnError: 'true'
+          teardown: 'true'
+          build: |
+            echo Deploying to surge.sh
+      - name: Get the preview_url
+        run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,19 +2,20 @@ name: Surge PR Preview
 
 on:
   workflow_run:
-    workflows: [ "Gatsby Publish" ]
+    workflows: [ "CI" ]
     types:
       - completed
-      - closed
+  pull_request_target:
+    types: [ closed ]
 
 jobs:
   preview:
     runs-on: ubuntu-20.04
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: github.event.pull_request_target || (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success')
     steps:
       - name: Download PR Artifact
         uses: dawidd6/action-download-artifact@v2
-        if: github.event.workflow_run.type == 'completed'
+        if: github.event.workflow_run && github.event.workflow_run.type == 'completed'
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success


### PR DESCRIPTION
I've had a first attempt at a surge integration so we can get previews of UI changes before merging them. 

Sadly, I don't think we can see if this works before merging, because surge has to run on the main repo. (I've gone for the model we use for `extensions` and `quarkusio.github.com`, where we assume people will fork the repo before making changes, so the preview runs from the main branch _against_ PRs.)

Before merging, a `SURGE_TOKEN` token needs to be added to the repo secrets. 