### PR TITLE
Publish bundle zip (as a release) on builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,17 @@ jobs:
       - name: Build bundle
         id: build_bundle
         run: gulp bundle
+
+      - name: Publish bundle
+        uses: ncipollo/release-action@v1
+        # Only try and deploy on merged code
+        if: "github.repository == 'quarkiverse/antora-ui-quarkiverse' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
+        with:
+          artifacts: "./build/ui-bundle.zip"
+          omitBody: true
+          allowUpdates: true
+          generateReleaseNotes: true
+          makeLatest: true
+          tag: "latest"
+          name: "HEAD"
+          replacesArtifacts: true


### PR DESCRIPTION
The Antora theme suggests using a URL of the format https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
to include a theme in an Antora site. Sadly, GitHub [don’t really support](https://github.com/actions/upload-artifact/issues/21) URLs of this form.
There are a few options for getting a URL to the latest bundle 
- Releases; it’s the natural mechanism, but it means we’d be doing a lot of releases and a lot of updates on the docs site to update links
- https://nightly.link/; specifically designed to give a stable URL to the latest build. However, it’s a GitHub app, which isn’t quite what we need, and there are concerns about rate limiting
- Committing the bundle back into source control. It creates a lot of churn in the commit history
Using a tagged release with fresh artifacts. This trick is described in https://dev.to/derlin/how-to-create-nightly-releases-with-github-actions-fpp. It should work with https://github.com/ncipollo/release-action
- Similar, but with a proper GitHub action: https://github.com/marketplace/actions/deploy-nightly, or https://github.com/viperproject/create-nightly-release, or https://github.com/viperproject/create-nightly-release. Sadly, none of these actions seem widely used, so I think using a popular release action seems best.