### PR TITLE
Build and publish preview site so preview has something to preview

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,25 @@ jobs:
         id: build_bundle
         run: gulp bundle
 
+      # Build the Antora preview (ends up in ./public)
+      - name: Build preview
+        # Only support previews on PRs
+        if: "github.event_name == 'pull_request'"
+        id: build_preview
+        run: gulp preview:build
+
+      - name: Store PR id
+        if: "github.event_name == 'pull_request'"
+        run: echo ${{ github.event.number }} > ./public/pr-id.txt
+
+      - name: Publishing directory for PR preview
+        if: "github.event_name == 'pull_request'"
+        uses: actions/upload-artifact@v2
+        with:
+          name: site
+          path: ./public
+          retention-days: 3
+
       - name: Publish bundle
         uses: ncipollo/release-action@v1
         # Only try and deploy on merged code


### PR DESCRIPTION
How hard is it to get a preview working? Hard, apparently. 

Since we're triggering the preview on workflow events, the PR builds need to publish an artifact that the second workflow can download. I also realised that `gulp bundle` makes a zip file with stylesheets, but nothing that can actually be viewed in a browser. `gulp preview` builds and serves a site, which is too much, but `gulp preview:build` seems to just generate the artifacts, which is what we want.