### PR TITLE
Use a freshly-generated tag for the release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,14 @@ jobs:
           path: ./public
           retention-days: 3
 
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.64.0 # Don't use @master or @v1 unless you're happy to test the latest version
+        # Only try and deploy on merged code
+        if: "github.repository == 'quarkiverse/antora-ui-quarkiverse' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # if you don't want to set write permissions use a PAT token
+          WITH_V: true
+
       - name: Publish bundle
         uses: ncipollo/release-action@v1
         # Only try and deploy on merged code
@@ -57,8 +65,7 @@ jobs:
           artifacts: "./build/ui-bundle.zip"
           omitBody: true
           allowUpdates: true
-          generateReleaseNotes: true
+          generateReleaseNotes: false
           makeLatest: true
-          tag: "latest"
           name: "HEAD"
           replacesArtifacts: true


### PR DESCRIPTION
Resolves #17

I have 

- Manually edited the `HEAD` release to remove the release notes and add a more informative body
- Added a step which tags the codebase, so that we can use that tag in the release
- Removed the tag option, which should automatically use the current tag
- Removed generation of the release notes, since it would just be details of the latest commit

I don’t know if this will correct the “released this yesterday [on June 12th]”
text, but it should fix some of the other issues. 

As with the initial preview and release work, this can’t really be tested in the PR itself. 