### PR TITLE
Use the tag name for the release name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,6 @@ jobs:
         with:
           artifacts: "./build/ui-bundle.zip"
           omitBody: true
-          allowUpdates: true
-          generateReleaseNotes: false
+          generateReleaseNotes: true
           makeLatest: true
           tag: "${{ steps.tag.outputs.new_tag }}"
-          name: "HEAD"
-          replacesArtifacts: true
-


### PR DESCRIPTION
Since we will be creating a unique release for every tag, we should use a unique name for the releases. We also do not need to worry about updating the release artifacts. 

This does have the disadvantage that releases proliferate, but the advantage that we don't end up with the tags not aligned to the release contents. 

https://github.com/quarkiverse/antora-ui-quarkiverse/releases/latest/download/ui-bundle.zip is the name we can use to access the release. 

Follow-on from #20.