### PR TITLE
Switch from Roboto to Open Sans for main text, to echo quarkus.io

### DIFF
--- a/docs/modules/ROOT/pages/inline-text-styles.adoc
+++ b/docs/modules/ROOT/pages/inline-text-styles.adoc
@@ -22,7 +22,7 @@ A bold <strong>word</strong>, or a bold <strong>phrase of text</strong>.
 Since `<strong>` is a semantic HTML element, it automatically inherits default styling (`font-weight: bold`) from the browser.
 If you want to override the browser styles, you'll need to define properties on the `strong` selector in the stylesheet for your UI.
 
-In the default UI, the `<strong>` element is styled in the 500 font weight of the current typeface (Roboto).
+In the default UI, the `<strong>` element is styled in the 500 font weight of the current typeface (Open Sans).
 For example:
 
 [example]
@@ -41,7 +41,7 @@ An italic <em>word</em>, or an italic <em>phrase of text</em>.
 Since `<em>` is a semantic HTML element, it automatically inherits default styling (`font-style: italic`) from the browser.
 If you want to override the browser styles, you'll need to define properties on the `em` selector in the stylesheet for your UI.
 
-In the default UI, the `em` element is styled in the italic font variant of the current typeface (Roboto).
+In the default UI, the `em` element is styled in the italic font variant of the current typeface (Open Sans).
 For example:
 
 [example]

--- a/package-lock.json
+++ b/package-lock.json
@@ -259,16 +259,16 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@fontsource/roboto": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
-      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA==",
+    "@fontsource/open-sans": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@fontsource/open-sans/-/open-sans-5.0.3.tgz",
+      "integrity": "sha512-L86qrEfW7IWSGojCtiPpw2/M6qKjxDG+EV4k1xMVFCkhh6Z6gyZwevqCt0yOvd1BmjrtUAIAfSzFTjBn3DeZJw==",
       "dev": true
     },
     "@fontsource/roboto-mono": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@fontsource/roboto-mono/-/roboto-mono-4.5.5.tgz",
-      "integrity": "sha512-krIslwmFMjDHtbSVKZLC6+PM6dOvw26OTm7rE7CrniJ4q5Lbfffx67RAlDI3ee0LsG6gIJd/JXBeUm+RgUsPqg==",
+      "version": "4.5.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto-mono/-/roboto-mono-4.5.10.tgz",
+      "integrity": "sha512-KrJdmkqz6DszT2wV/bbhXef4r0hV3B0vw2mAqei8A2kRnvq+gcJLmmIeQ94vu9VEXrUQzos5M9lH1TAAXpRphw==",
       "dev": true
     },
     "@jridgewell/resolve-uri": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "devDependencies": {
     "@asciidoctor/core": "~2.2",
-    "@fontsource/roboto": "~4.5",
+    "@fontsource/open-sans": "^5.0.3",
     "@fontsource/roboto-mono": "~4.5",
     "autoprefixer": "~9.7",
     "browser-pack-flat": "~3.4",

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -1,4 +1,4 @@
-@import "typeface-roboto.css";
+@import "typeface-open-sans.css";
 @import "typeface-roboto-mono.css";
 @import "vars.css";
 @import "base.css";

--- a/src/css/typeface-open-sans.css
+++ b/src/css/typeface-open-sans.css
@@ -1,39 +1,39 @@
 @font-face {
-  font-family: "Roboto";
+  font-family: "Open Sans";
   font-style: normal;
   font-weight: 400;
   src:
-    url(~@fontsource/roboto/files/roboto-latin-400-normal.woff2) format("woff2"),
-    url(~@fontsource/roboto/files/roboto-latin-400-normal.woff) format("woff");
+    url(~@fontsource/open-sans/files/open-sans-latin-400-normal.woff2) format("woff2"),
+    url(~@fontsource/open-sans/files/open-sans-latin-400-normal.woff) format("woff");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @font-face {
-  font-family: "Roboto";
+  font-family: "Open Sans";
   font-style: italic;
   font-weight: 400;
   src:
-    url(~@fontsource/roboto/files/roboto-latin-400-italic.woff2) format("woff2"),
-    url(~@fontsource/roboto/files/roboto-latin-400-italic.woff) format("woff");
+    url(~@fontsource/open-sans/files/open-sans-latin-400-italic.woff2) format("woff2"),
+    url(~@fontsource/open-sans/files/open-sans-latin-400-italic.woff) format("woff");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @font-face {
-  font-family: "Roboto";
+  font-family: "Open Sans";
   font-style: normal;
   font-weight: 500;
   src:
-    url(~@fontsource/roboto/files/roboto-latin-500-normal.woff2) format("woff2"),
-    url(~@fontsource/roboto/files/roboto-latin-500-normal.woff) format("woff");
+    url(~@fontsource/open-sans/files/open-sans-latin-500-normal.woff2) format("woff2"),
+    url(~@fontsource/open-sans/files/open-sans-latin-500-normal.woff) format("woff");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @font-face {
-  font-family: "Roboto";
+  font-family: "Open Sans";
   font-style: italic;
   font-weight: 500;
   src:
-    url(~@fontsource/roboto/files/roboto-latin-500-italic.woff2) format("woff2"),
-    url(~@fontsource/roboto/files/roboto-latin-500-italic.woff) format("woff");
+    url(~@fontsource/open-sans/files/open-sans-latin-500-italic.woff2) format("woff2"),
+    url(~@fontsource/open-sans/files/open-sans-latin-500-italic.woff) format("woff");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -24,7 +24,7 @@
   --body-font-size--print: 0.9375em; /* 15px */
   --body-line-height: 1.15;
   --body-font-color: var(--color-jet-70);
-  --body-font-family: "Roboto", sans-serif;
+  --body-font-family: "Open Sans", sans-serif;
   --body-font-weight-bold: 500;
   --monospace-font-family: "Roboto Mono", monospace;
   --monospace-font-weight-bold: 500;


### PR DESCRIPTION
We should use the same font as the main http://quarkus.io site. For the monospace fonts, both the antora default and quarkus.io use Roboto Mono, so no change needed.

*Before*

<img width="1665" alt="image" src="https://github.com/quarkiverse/antora-ui-quarkiverse/assets/11509290/10a292c3-48fa-4b8e-bc26-4fdd00a85603">

*After*

<img width="1665" alt="image" src="https://github.com/quarkiverse/antora-ui-quarkiverse/assets/11509290/d4fbc812-5e6f-47d2-9ae7-ea496ada9e38">
