### PR TITLE
Adjust flex to prevent version wrapping

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -2,7 +2,8 @@ antoraVersion: '1.0.0'
 site:
   url: http://localhost:5252
   title: Brand Docs
-  homeUrl: &home_url /xyz/5.2/index.html
+  homeUrl: &home_url /xyz/dev/index.html
+
   components:
   - name: abc
     title: Project ABC
@@ -18,7 +19,7 @@ site:
     latestVersion: *latest_version_abc
   - &component
     name: xyz
-    title: &component_title Project NotReally
+    title: &component_title Project NotReally Has A VeryLong Title
     url: /xyz/6.0/index.html
     versions:
     - &latest_version_xyz
@@ -28,8 +29,8 @@ site:
     - &component_version
       title: *component_title
       url: '#'
-      version: '5.2'
-      displayVersion: '5.2'
+      version: 'dev'
+      displayVersion: 'dev'
     - url: '#'
       version: '5.1'
       displayVersion: '5.1'
@@ -58,8 +59,8 @@ page:
   title: Minecraft Observability
   component: *component
   componentVersion: *component_version
-  version: '5.2'
-  displayVersion: '5.2'
+  version: 'dev'
+  displayVersion: 'dev'
   module: ROOT
   relativeSrcPath: index.adoc
   editUrl: http://example.com/project-xyz/blob/main/index.adoc
@@ -78,14 +79,14 @@ page:
     url: '#'
     urlType: fragment
   - content: Minecraft Observability
-    url: /xyz/5.2/index.html
+    url: /xyz/dev/index.html
     urlType: internal
   versions:
   - version: '6.0'
     displayVersion: '6.0'
     url: '#'
-  - version: '5.2'
-    displayVersion: '5.2'
+  - version: 'dev'
+    displayVersion: 'dev'
     url: '#'
   - version: '5.1'
     displayVersion: '5.1'
@@ -102,13 +103,13 @@ page:
       urlType: fragment
       items:
       - content: Minecraft extension
-        url: /xyz/5.2/index.html
+        url: /xyz/dev/index.html
         urlType: internal
       - content: Cu Solet
-        url: '/xyz/5.2/index.html#cu-solet'
+        url: '/xyz/dev/index.html#cu-solet'
         urlType: internal
       - content: English + 中文
-        url: '/xyz/5.2/index.html#english+中文'
+        url: '/xyz/dev/index.html#english+中文'
         urlType: internal
     - content: Liber Recusabo
       url: '#liber-recusabo'
@@ -122,7 +123,7 @@ page:
         url: '#'
         urlType: fragment
       - content: Some Code
-        url: '/xyz/5.2/index.html#some-code'
+        url: '/xyz/dev/index.html#some-code'
         urlType: internal
   attributes:
     quarkiverse_root_url: https://github.com/quarkiverse

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -185,6 +185,7 @@ html.is-clipped--nav {
 }
 
 .nav-panel-explore .context .version {
+  flex-shrink: 0;
   display: flex;
   align-items: inherit;
 }


### PR DESCRIPTION
Before (after updating the ui model yml to reproduce):

<img width="317" alt="image" src="https://github.com/quarkiverse/antora-ui-quarkiverse/assets/11509290/227659ed-4c1b-4a5a-a865-b57fcad0ed7d">

After: 

<img width="324" alt="image" src="https://github.com/quarkiverse/antora-ui-quarkiverse/assets/11509290/7da3b526-7c78-4a03-adf9-79c35e897acb">
