### PR TITLE
Fix fonts on admonitions (and add background)

### DIFF
--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -11,6 +11,7 @@
   --color-red: #ff004a;
   --color-dark-red: #c00;
   --color-cta-blue: #0b58ab;
+  --color-ultralight-grey: #fafafa;
   --color-grey-0: #efefef;
   --color-grey-1: #aaa;
   --color-grey-2: #555;
@@ -97,7 +98,7 @@
   --abstract-background: var(--color-black);
   --abstract-font-color: var(--color-black);
   --abstract-border-color: var(--panel-border-color);
-  --admonition-background: var(--panel-background);
+  --admonition-background: var(--color-ultralight-grey);
   --admonition-label-font-weight: var(--body-font-weight-bold);
   --caption-font-color: var(--color-grey-3);
   --caption-font-weight: var(--body-font-weight-bold);

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,1 +1,1 @@
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
+<!-- This wasn't displaying icons, and it was breaking the fonts on the admonitions   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">-->


### PR DESCRIPTION
The font on the admonitions (like tips, and warnings) was a random serif font. 

It turns out it's because we were trying to use font awesome, but instead of getting icons, it just messed up the fonts. Font awesome does seem to be getting harder to use; I notice it's also missing in the default antora UI, and when I had a quick look about introducing it, it seemed to need kits and credentials and all sorts of fuss. 

I've raised #34 to get the icons actually working. 

While I was debugging I noticed that the original UI had a pale grey background on the admonitions, so I've added one in. 

Before:

<img width="1070" alt="image" src="https://github.com/quarkiverse/antora-ui-quarkiverse/assets/11509290/3f8bf275-de2e-43df-866c-d913c72f2e3c">


After:

<img width="1106" alt="image" src="https://github.com/quarkiverse/antora-ui-quarkiverse/assets/11509290/92627826-1a8c-4e80-8369-902b4924f21d">
