### PR TITLE
Better url for hidden navigation

### DIFF
--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -12,8 +12,8 @@ site:
     versions:
     - &component_version
       url: '#'
-      version: 'noversion'
-      displayVersion: 'noversion'
+      version: 'explore'
+      displayVersion: 'explore'
     latest: *component_version
   - name: xyz
     title: Project NotReally
@@ -57,8 +57,8 @@ page:
   title: Minecraft Observability
   component: *component
   componentVersion: *component_version
-  version: 'noversion'
-  displayVersion: 'noversion'
+  version: 'explore'
+  displayVersion: 'explore'
   module: ROOT
   relativeSrcPath: index.adoc
   editUrl: http://example.com/project-xyz/blob/main/index.adoc

--- a/src/partials/nav-explore.hbs
+++ b/src/partials/nav-explore.hbs
@@ -1,6 +1,6 @@
 <div class="nav-panel-explore{{#unless page.navigation}} is-active{{/unless}}" data-panel="explore">
   {{#if page.component}}
-    {{#if (eq "noversion" ./page.componentVersion.version )}}
+    {{#if (eq "explore" ./page.componentVersion.version )}}
         <!--  placeholder toolbar to align with main toolbar-->
         <div class="toolbar toolbar-padder" style="position: static"></div>
       {{ else }}
@@ -12,7 +12,7 @@
   {{/if}}
   <ul class="components">
     {{#each site.components}}
-      {{#unless (eq "noversion" ./latest.version)}}
+      {{#unless (eq "explore" ./latest.version)}}
         <li class="component{{#if (eq this @root.page.component)}} is-current{{/if}}">
         <a class="title" href="{{{relativize ./url}}}">{{{./title}}}</a>
         <ul class="versions">

--- a/src/partials/page-versions.hbs
+++ b/src/partials/page-versions.hbs
@@ -1,6 +1,6 @@
 {{#with page.versions}}
 <div class="page-versions">
-  {{#unless (eq "noversion" @root.page.componentVersion.displayVersion )}}
+  {{#unless (eq "explore" @root.page.componentVersion.displayVersion )}}
   <button class="version-menu-toggle" title="Show other versions of page">{{@root.page.componentVersion.displayVersion}}</button>
   <div class="version-menu">
     {{#each this}}


### PR DESCRIPTION
@gsmet points out that urls with 'noversion' in them are a bit confusing, and we should choose something that's less meaningful in terms of what we're doing with antora, but more human friendly. 

Note that this change will break google search for 'quarkiverse docs,' at least until google reindexes.