### PR TITLE
Add menu item for Quarkiverse Hub

### DIFF
--- a/src/partials/article-404.hbs
+++ b/src/partials/article-404.hbs
@@ -1,7 +1,8 @@
 <article class="doc">
 <h1 class="page">{{{or page.title 'Page Not Found'}}}</h1>
 <div class="paragraph">
-<p>The page you&#8217;re looking for does not exist. It may have been moved. You can{{#with site.homeUrl}} return to the <a href="{{{this}}}">start page</a>, or{{/with}} follow one of the links in the navigation to the left.</p>
+<p>The page you&#8217;re looking for does not exist. It may have been moved.
+  You can{{#with site.homeUrl}} return to the <a href="{{{this}}}">start page</a>, or{{/with}} browse the extensions in the navigation bar on the left.</p>
 </div>
 <div class="paragraph">
 <p>If you arrived on this page by clicking on a link, please notify the owner of the site that the link is broken.

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -31,11 +31,14 @@
         <div class="navbar-item has-dropdown is-hoverable">
           <div class="navbar-link">Extensions</div>
             <div class="navbar-dropdown">
-            <a class="navbar-item" href="http://quarkus.io/extensions">Browse Extensions</a>
-                <a class="navbar-item" href="http://quarkus.io/faq/#what-is-a-quarkus-extension">Use Extensions</a>
-                <a class="navbar-item" href="http://quarkus.io/guides/writing-extensions">
+            <a class="navbar-item" href="https://quarkus.io/extensions">Browse Extensions</a>
+                <a class="navbar-item" href="https://quarkus.io/faq/#what-is-a-quarkus-extension">Use Extensions</a>
+                <a class="navbar-item" href="https://quarkus.io/guides/writing-extensions">
                   Create Extensions
                 </a>
+              <a class="navbar-item" href="https://hub.quarkiverse.io">
+                Share Extensions
+              </a>
             </div>
           </div>
         <div class="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
I also made minor updates to the 404 page to make it more tuned to the docs site.

Now that http://extensions.quarkus.io and http://quarkus.io link to the hub page, we should mirror that to the menus in docs.quarkiverse.io. 

Ideally our sites wouldn't have three different static generation mechanisms so there was less manual mirroring, but that's a different conversation. :) 