### PR TITLE
Add commonly used icons to loaded set.

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -31,6 +31,8 @@ E = mc^2^.
 Eum an doctus <<liber-recusabo,maiestatis efficiantur>>.
 Eu mea inani iriure.footnote:[Quisque porta facilisis tortor, vitae bibendum velit fringilla vitae! Lorem ipsum dolor sit amet, consectetur adipiscing elit.]
 
+And here is a lock icon icon:lock[title=Looks like a lock] and a heart icon icon:heart[title=Looks like a heart] and an exclamation icon:question-circle[title=title] (the icons should be before this text). Any icons used need to be explicitly loaded in the `src/js/vendor/fontawesome-icon-defs.js` file.
+
 [,json]
 ----
 {

--- a/src/js/vendor/fontawesome-icon-defs.js
+++ b/src/js/vendor/fontawesome-icon-defs.js
@@ -14,8 +14,22 @@ var window
     'far fa-copy',
     'far fa-check-square',
     'fab fa-github',
+    'fab fa-gitlab',
     'far fa-square',
     'fab fa-twitter',
+    'fab fa-redhat',
+    'fab fa-aws',
+    'fab fa-amazon',
+    'fab fa-microsoft',
+    'fab fa-google',
+    'fab fa-vaadin',
+    'fab fa-stackexchange',
+    'fab fa-free-code-camp',
+    'fab fa-react',
+    'fab fa-java',
+    'fas fa-lock',
+    'fas fa-heart',
+    'fas fa-question-circle',
   ]
   var iconDefs = (scope.FontAwesomeIconDefs = [])
   iconDefs.admonitionIcons = admonitionIcons


### PR DESCRIPTION
#57 added back fontawesome icon support, but only icons which have been pre-loaded are supported, so it does not fix #55. In fact, it makes it slightly worse, because it replaces the blank space we used to have with a flashing question mark. Any icons used need to be explicitly loaded in the `src/js/vendor/fontawesome-icon-defs.js` file. This is an efficiency for site loading, but annoying in terms of our developer experience. 

I've added in the lock icon, and I’ve searched the quarkiverse org to identify any icons currently being used, and preemptively added some ones that might end up in docs.

Resolves #55.