### PR TITLE
Improve the rendering of tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /build/
 /node_modules/
 /public/
+
+# Eclipse
+.project
+.settings/

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -231,6 +231,31 @@ h|Total
 |6
 |===
 
+.Stripes odd
+[#dependencies%autowidth,stripes=odd]
+|===
+|Library |Version
+
+|eslint
+|^1.7.3
+
+|eslint-config-gulp
+|^2.0.0
+
+|expect
+|^1.20.2
+
+|istanbul
+|^0.4.3
+
+|istanbul-coveralls
+|^1.0.3
+
+|jscs
+|^2.3.5
+
+|===
+
 Cum dicat putant ne.
 Est in reque homero principes, meis deleniti mediocrem ad has.
 Altera atomorum his ex, has cu elitr melius propriae.

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -257,11 +257,6 @@
   border-width: 1px 0;
 }
 
-.doc table.grid-all > thead th,
-.doc table.grid-rows > thead th {
-  border-bottom-width: 2.5px;
-}
-
 .doc table.frame-all {
   border-width: 1px;
 }

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -116,8 +116,8 @@
   --quote-font-color: var(--color-grey-4);
   --quote-attribution-font-color: var(--color-grey-3);
   --sidebar-background: var(--color-grey-0);
-  --table-border-color: var(--panel-border-color);
-  --table-stripe-background: var(--panel-background);
+  --table-border-color: var(--color-grey-1);
+  --table-stripe-background: var(--color-grey-0);
   --table-footer-background: linear-gradient(to bottom, var(--color-grey-1) 0%, var(--color-white) 100%);
   /* toc */
   --toc-font-color: var(--nav-muted-color);


### PR DESCRIPTION
* Let the border color match the border color of code blocks
* Have grey background for striped rows
* Have same border at the bottom of table header cells as everywhere
else

Before: 
![image](https://github.com/quarkiverse/antora-ui-quarkiverse/assets/1826249/dc13ff94-aef1-4492-8257-379eafb8cd91)

After: 
![image](https://github.com/quarkiverse/antora-ui-quarkiverse/assets/1826249/72294614-c455-4b7a-b888-881250155c9f)
