### PR TITLE
Fix navigation links

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -19,18 +19,18 @@
         <div class="navbar-item has-dropdown is-hoverable">
           <div class="navbar-link">Learn</div>
             <div class="navbar-dropdown">
-            <a class="navbar-item" href="http://quarkus.io/get-started">Get Started</a>
-              <a class="navbar-item" href="http://quarkus.io/guides">Documentation</a>
-              <a class="navbar-item" href="http://quarkus.io/qtips">
+            <a class="navbar-item" href="https://quarkus.io/get-started/">Get Started</a>
+              <a class="navbar-item" href="https://quarkus.io/guides/">Documentation</a>
+              <a class="navbar-item" href="https://quarkus.io/qtips/">
                 "Q" Tip Videos
               </a>
-              <a class="navbar-item" href="http://quarkus.io/books">Books</a>
+              <a class="navbar-item" href="https://quarkus.io/books/">Books</a>
             </div>
           </div>
         <div class="navbar-item has-dropdown is-hoverable">
           <div class="navbar-link">Extensions</div>
             <div class="navbar-dropdown">
-            <a class="navbar-item" href="https://quarkus.io/extensions">Browse Extensions</a>
+            <a class="navbar-item" href="https://quarkus.io/extensions/">Browse Extensions</a>
                 <a class="navbar-item" href="https://quarkus.io/faq/#what-is-a-quarkus-extension">Use Extensions</a>
                 <a class="navbar-item" href="https://quarkus.io/guides/writing-extensions">
                   Create Extensions
@@ -44,12 +44,12 @@
           <div class="navbar-link">Community</div>
           <div class="navbar-dropdown is-right">
             <a class="navbar-item" href="https://quarkusio.zulipchat.com">Chat</a>
-            <a class="navbar-item" href="http://quarkus.io/support/">Support</a>
-            <a class="navbar-item" href="http://quarkus.io/blog">Blog</a>
-            <a class="navbar-item" href="http://quarkus.io/discussion">Discussion</a>
-            <a class="navbar-item" href="http://quarkus.io/insights">Podcast</a>
-            <a class="navbar-item" href="http://quarkus.io/events">Events</a>
-            <a class="navbar-item" href="http://quarkus.io/newsletter">
+            <a class="navbar-item" href="https://quarkus.io/support/">Support</a>
+            <a class="navbar-item" href="https://quarkus.io/blog/">Blog</a>
+            <a class="navbar-item" href="https://quarkus.io/discussion/">Discussion</a>
+            <a class="navbar-item" href="https://quarkus.io/insights/">Podcast</a>
+            <a class="navbar-item" href="https://quarkus.io/events/">Events</a>
+            <a class="navbar-item" href="https://quarkus.io/newsletter/">
               Newsletter
             </a>
           </div>


### PR DESCRIPTION
* Use the `https://` and the canonical URL of the page
* The **Training** menu item (pointing to http://quarkus.io/training) is removed because the page does not exist (404 error on the website)