### PR TITLE
Fix configuration layout after regression caused by Search

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -40,7 +40,7 @@
   display: block;
   padding: 0 30px;
 
-  .content {
+  > .content {
     display: flex;
   }
 


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-langchain4j/issues/1292

Apparently, everything is under .qs-target now so matching all .content is far too broad.
Restricting the CSS rule to direct children only fixes the issue.