### PR TITLE
Fix admonition icon size

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -377,8 +377,8 @@
 .doc .admonitionblock td.icon i:empty::before,
 .doc .admonitionblock td.icon .svga {
   content: "";
-  height: inherit;
-  width: 1.5rem;
+  width: 1em;
+  height: 1em;
   margin: 0 0.25rem 0 -0.5rem;
   border-radius: 0.45rem 0 0 0.45rem;
   padding: 0.2em 0.2em 0.3em 0.3em;


### PR DESCRIPTION
I have noticed the following issue a while back:

![Screenshot from 2025-04-08 11-15-52](https://github.com/user-attachments/assets/ba23f04c-38e9-4f60-8581-24ecdee3b537)

Icon is too large and alpha background used to get a darker color is too large.

This patch fixes it.