### PR TITLE
Update search placeholder to clarify that it searches all guides

### DIFF
--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -73,6 +73,7 @@
 
 .search {
   margin-right: 10px;
+  width: 270px;
 }
 
 .search input {

--- a/src/partials/search-bar.hbs
+++ b/src/partials/search-bar.hbs
@@ -6,6 +6,6 @@
          origin-filter="quarkiverse-hub"
 >
   <div class="search">
-    <input name="q" type="search" placeholder="Search by keyword" autocomplete="off">
+    <input name="q" type="search" placeholder="Search all Quarkiverse docs by keyword" autocomplete="off">
   </div>
 </qs-form>


### PR DESCRIPTION
* https://github.com/quarkiverse/antora-ui-quarkiverse/issues/116

I'm not going to say that this one `c l o s e s` ^ 🙂 as I'd assume we want to keep it opened so we could address option (B) 🙂 

<img width="1474" height="404" alt="image" src="https://github.com/user-attachments/assets/80e02135-296b-4885-b796-42ec28554abe" />
vs orginal:
<img width="1474" height="404" alt="image" src="https://github.com/user-attachments/assets/ace9ef2d-2d27-452c-b774-bfe8b35131d3" />
